### PR TITLE
Add player profile page

### DIFF
--- a/src/app/player-profile/layout.tsx
+++ b/src/app/player-profile/layout.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image";
+import Container from "@/components/container";
+import { TopNav } from "@/components/nav";
+
+export default function PlayerProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <TopNav
+        title={
+          <Image
+            src="/powerlogo.avif"
+            alt="Power Logo"
+            width={180}
+            height={180}
+            className="object-contain"
+          />
+        }
+      />
+      <main>
+        <Container>{children}</Container>
+      </main>
+    </>
+  );
+}

--- a/src/app/player-profile/page.tsx
+++ b/src/app/player-profile/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { playerData } from "@/lib/data";
+
+export default function PlayerProfile() {
+  const player = playerData[0];
+
+  if (!player) {
+    return (
+      <div className="p-6 space-y-4">
+        <p>Player not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Link href="/roster" className="text-primary hover:underline text-sm">
+        &larr; Back to Roster
+      </Link>
+      <div className="flex flex-col items-center">
+        {player.imageUrl && (
+          <img
+            src={player.imageUrl}
+            alt={player.name}
+            width={128}
+            height={128}
+            className="rounded-full border mb-4"
+          />
+        )}
+        <h1 className="text-3xl font-bold text-primary mb-1">{player.name}</h1>
+        <p className="text-muted-foreground mb-4">{player.position}</p>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div className="font-medium text-muted-foreground">Number</div>
+          <div>{player.number}</div>
+          <div className="font-medium text-muted-foreground">Class</div>
+          <div>{player.class}</div>
+          <div className="font-medium text-muted-foreground">Height</div>
+          <div>{player.height}</div>
+          <div className="font-medium text-muted-foreground">Weight</div>
+          <div>{player.weight} lbs</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/config/site.tsx
+++ b/src/config/site.tsx
@@ -1,4 +1,4 @@
-import { Gauge, type LucideIcon, Users, Dumbbell, ClipboardList, MessagesSquare, Bot } from "lucide-react";
+import { Gauge, type LucideIcon, Users, User, Dumbbell, ClipboardList, MessagesSquare, Bot } from "lucide-react";
 
 export type SiteConfig = typeof siteConfig;
 export type Navigation = {
@@ -23,7 +23,12 @@ export const navigations: Navigation[] = [
     name: "Roster",
     href: "/roster",
   },
-   {
+  {
+    icon: User,
+    name: "Player Profile",
+    href: "/player-profile",
+  },
+  {
     icon: Dumbbell,
     name: "Workouts",
     href: "/workouts",


### PR DESCRIPTION
## Summary
- add a Player Profile navigation item
- implement `/player-profile` page with sample player info
- add layout for the new page

## Testing
- `pnpm lint` *(fails: Unexpected console statements)*
- `pnpm build` *(fails: Failed to fetch font `Gabarito` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684cee415960832b85b5355891e8169d